### PR TITLE
Fix injected parameter warning not considering parent classes

### DIFF
--- a/Analyzers/Rules/MHA013-InjectedParameterNotFoundOnTargetMethod.cs
+++ b/Analyzers/Rules/MHA013-InjectedParameterNotFoundOnTargetMethod.cs
@@ -47,7 +47,7 @@ internal readonly struct InjectedParamterNotFoundOnTargetMethod : IPatchMethodRu
             {
                 var fieldInjectionMatch = HarmonyHelpers.FieldInjectionRegex.Match(p.Name);
                 if (fieldInjectionMatch.Success &&
-                    methodData.TargetMethod.ContainingType.GetMembers().OfType<IFieldSymbol>().Any(f =>
+                    GetAllFields(methodData.TargetMethod.ContainingType).Any(f =>
                         f.Name == fieldInjectionMatch.Groups[1].Value &&
                         methodData.Compilation.ClassifyConversion(f.Type, p.Type).IsStandardImplicit()))
                     continue;
@@ -80,6 +80,20 @@ internal readonly struct InjectedParamterNotFoundOnTargetMethod : IPatchMethodRu
         }
     }
 
+    // Harmony supports injecting both declared and inherited fields.
+    private static IEnumerable<IFieldSymbol> GetAllFields(INamedTypeSymbol type)
+    {
+        var current = type;
+        while (current is not null)
+        {
+            foreach (var field in current.GetMembers().OfType<IFieldSymbol>())
+            {
+                yield return field;
+            }
+            current = current.BaseType;
+        }
+    }
+    
     public ImmutableArray<Diagnostic> Check(
         PatchMethodData methodData,
         SemanticModel _1,

--- a/Test/MHA013/NoMatchForInjectedArgument.cs
+++ b/Test/MHA013/NoMatchForInjectedArgument.cs
@@ -6,8 +6,15 @@ using Verify = PatchClassAnalyzerVerifier;
 public class NoMatchForInjectedArgument
 {
     const string targetClass = """
-class TargetType
+class ParentType {
+    private static bool staticParentField;
+    private bool parentField;
+}
+
+class TargetType : ParentType
 {
+    private bool field;
+    
     public void TargetMethod(string s) {}
 }
 """;
@@ -46,5 +53,39 @@ static class Patch
         await Verify.VerifyAnalyzerAsync(
             new TestSources(targetClass, testPatch),
             Verify.Diagnostic("MHA013").WithLocation(0));
+    }
+    
+    [TestMethod]
+    public async Task ValidInjectedField()
+    {
+        const string testPatch = """
+using HarmonyLib;
+
+[HarmonyPatch(typeof(TargetType), nameof(TargetType.TargetMethod))]
+static class Patch
+{
+    static void Postfix(string s, ref bool ___field) {}
+}
+""";
+
+        await Verify.VerifyAnalyzerAsync(
+            new TestSources(targetClass, testPatch), []);
+    }    
+    
+    [TestMethod]
+    public async Task ValidInjectedParentField()
+    {
+        const string testPatch = """
+using HarmonyLib;
+
+[HarmonyPatch(typeof(TargetType), nameof(TargetType.TargetMethod))]
+static class Patch
+{
+    static void Postfix(string s, ref bool ___parentField, ref bool ___staticParentField) {}
+}
+""";
+
+        await Verify.VerifyAnalyzerAsync(
+            new TestSources(targetClass, testPatch), []);
     }
 }


### PR DESCRIPTION
Harmony does support injecting fields from parent classes, but the diagnostic didn't consider that causing false-positive warnings